### PR TITLE
Update README.md - AOT Compile Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ import {RouterModule} from '@angular/router';
 
 import {routes} from './app.routes';
 
+export function LocalizeRouterHttpLoaderFactory(translate, location, settings, http) {
+  return new LocalizeRouterHttpLoader(translate, location, settings, http);
+}
+
 @NgModule({
   imports: [
     BrowserModule,
@@ -68,8 +72,7 @@ import {routes} from './app.routes';
     LocalizeRouterModule.forRoot(routes, {
       parser: {
         provide: LocalizeParser,
-        useFactory: (translate, location, settings, http) =>
-            new LocalizeRouterHttpLoader(translate, location, settings, http),
+        useFactory: LocalizeRouterHttpLoaderFactory,
         deps: [TranslateService, Location, LocalizeRouterSettings, HttpClient]
       }
     }),


### PR DESCRIPTION
Ahead-of-time complilation runs into the following error, so converting the useFactory to an export function solves this.

ERROR in Error encountered resolving symbol values statically. Function calls are not supported. Consider replacing the function or lambda with a reference to an exported function (position 44:21 in the original .ts file), resolving symbol AppRoutingModule in C:/Users/alexander.knapstein/Development/*/src/app/app-routing.module.ts

ERROR in ./src/main.ts
Module not found: Error: Can't resolve './$$_gendir/app/app.module.ngfactory' in 'C:\Users\alexander.knapstein\Development\*\src'
 @ ./src/main.ts 3:0-74
 @ multi ./src/main.ts